### PR TITLE
Bootstrap Phase A motion-control serial foundation

### DIFF
--- a/bridge/jetson_serial/motion_bridge.py
+++ b/bridge/jetson_serial/motion_bridge.py
@@ -1,0 +1,47 @@
+"""Bridge mínimo para Fase A: envío de comandos y parseo de estado serial."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class MotionCommand:
+    seq: int
+    cmd: str
+    duration_ms: int | None = None
+
+    def to_wire(self) -> bytes:
+        payload = {"type": "cmd_motion", "seq": self.seq, "cmd": self.cmd}
+        if self.duration_ms is not None:
+            payload["duration_ms"] = self.duration_ms
+        return (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+class MotionBridge:
+    def __init__(self, serial_port):
+        self.serial = serial_port
+        self.seq = 0
+
+    def send(self, cmd: str, duration_ms: int | None = None) -> int:
+        self.seq += 1
+        command = MotionCommand(seq=self.seq, cmd=cmd, duration_ms=duration_ms)
+        self.serial.write(command.to_wire())
+        return self.seq
+
+    def ping(self) -> int:
+        return self.send("PING")
+
+    def stop(self, duration_ms: int = 500) -> int:
+        return self.send("STOP", duration_ms=duration_ms)
+
+    def read_status(self, timeout_s: float = 1.0) -> dict:
+        start = time.monotonic()
+        while time.monotonic() - start <= timeout_s:
+            raw = self.serial.readline()
+            if not raw:
+                continue
+            return json.loads(raw.decode("utf-8").strip())
+        raise TimeoutError("No se recibió motion_status en el tiempo esperado")

--- a/bridge/jetson_serial/phase_a_check.py
+++ b/bridge/jetson_serial/phase_a_check.py
@@ -1,0 +1,87 @@
+"""CLI de verificación Fase A desde un solo punto."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+from bridge.jetson_serial.motion_bridge import MotionBridge
+
+
+class FakeSerial:
+    def __init__(self):
+        self.writes = []
+        self.inbox = []
+
+    def write(self, data: bytes):
+        self.writes.append(data)
+        msg = json.loads(data.decode("utf-8").strip())
+        if msg.get("cmd") in {"PING", "STOP", "STATUS"}:
+            self.inbox.append(
+                json.dumps(
+                    {
+                        "type": "motion_status",
+                        "seq_ack": msg["seq"],
+                        "mode": "SAFE",
+                        "left_pwm": 1500,
+                        "right_pwm": 1500,
+                        "vertical_pwm": 1500,
+                        "error": "NONE",
+                    }
+                ).encode("utf-8")
+                + b"\n"
+            )
+
+    def readline(self) -> bytes:
+        if self.inbox:
+            return self.inbox.pop(0)
+        return b""
+
+
+def run_check(serial_port, stop_interval_ms: int = 500, cycles: int = 3) -> int:
+    bridge = MotionBridge(serial_port)
+
+    seq = bridge.ping()
+    status = bridge.read_status(timeout_s=1.0)
+    print(f"PING seq={seq} -> {status}")
+
+    for _ in range(cycles):
+        seq = bridge.stop(duration_ms=stop_interval_ms)
+        status = bridge.read_status(timeout_s=1.0)
+        print(f"STOP seq={seq} -> {status}")
+        time.sleep(stop_interval_ms / 1000)
+
+    seq = bridge.send("STATUS")
+    status = bridge.read_status(timeout_s=1.0)
+    print(f"STATUS seq={seq} -> {status}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Chequeo Fase A (PING/STOP/STATUS)")
+    parser.add_argument("--dry-run", action="store_true", help="Usa puerto serial simulado")
+    parser.add_argument("--port", help="Puerto serial real, ej: /dev/ttyUSB0")
+    parser.add_argument("--baud", type=int, default=115200)
+    args = parser.parse_args()
+
+    if args.dry_run:
+        return run_check(FakeSerial())
+
+    if not args.port:
+        print("Error: usa --dry-run o define --port", file=sys.stderr)
+        return 2
+
+    try:
+        import serial  # type: ignore
+    except ImportError:
+        print("pyserial no está instalado. Ejecuta: pip install pyserial", file=sys.stderr)
+        return 3
+
+    with serial.Serial(args.port, args.baud, timeout=0.2) as ser:
+        return run_check(ser)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/protocols/MOTION_SERIAL_PROTOCOL.md
+++ b/docs/protocols/MOTION_SERIAL_PROTOCOL.md
@@ -1,0 +1,57 @@
+# MOTION_SERIAL_PROTOCOL
+
+Protocolo inicial (Fase A) para control seguro Jetson/PC ↔ ESP32 Movimiento.
+
+## Objetivo
+
+Validar comunicación serial y seguridad antes de integrar SLAM/Kinect/sensores pesados.
+
+## Transporte
+
+- Medio: UART sobre USB (CDC)
+- Formato: JSON por línea (`\n`)
+- Baudrate inicial recomendado: `115200`
+- Timeout de enlace: `1000 ms`
+
+## Comandos permitidos en Fase A
+
+- `PING`
+- `STOP`
+- `SET_SAFE`
+- `SET_AUTO`
+- `SET_MANUAL`
+- `STATUS`
+
+## Mensaje de comando
+
+```json
+{"type":"cmd_motion","seq":1,"cmd":"STOP","duration_ms":500}
+```
+
+Campos mínimos:
+
+- `type`: siempre `cmd_motion`
+- `seq`: entero incremental
+- `cmd`: comando del set permitido
+- `duration_ms`: obligatorio para comandos de movimiento (en Fase A solo se usa con STOP)
+
+## Mensaje de estado
+
+```json
+{"type":"motion_status","seq_ack":1,"mode":"SAFE","left_pwm":1500,"right_pwm":1500,"vertical_pwm":1500,"error":"NONE"}
+```
+
+## Failsafe obligatorio
+
+Si no llega ningún comando válido durante `1000 ms`:
+
+1. Poner todos los PWM a neutro (1500 µs)
+2. Cambiar a `SAFE`
+3. Reportar `error: "TIMEOUT"`
+
+## Criterio de aceptación Fase A
+
+- Jetson/PC envía `PING` y recibe confirmación.
+- Jetson/PC envía `STOP` periódicamente (cada 500 ms).
+- ESP32 mantiene neutro y responde `motion_status`.
+- Al cortar comandos por >1000 ms, entra en failsafe.

--- a/docs/protocols/PHASE_A_RUNBOOK.md
+++ b/docs/protocols/PHASE_A_RUNBOOK.md
@@ -1,0 +1,42 @@
+# PHASE_A_RUNBOOK
+
+Guía de arranque desde un solo punto para Fase A (movimiento seguro).
+
+## 1) Un solo comando para correr todo
+
+Modo simulación (sin hardware):
+
+```bash
+./scripts/run-motion-phase-a.sh
+```
+
+Modo hardware (ESP32 conectado por USB):
+
+```bash
+./scripts/run-motion-phase-a.sh hardware /dev/ttyUSB0
+```
+
+## 2) Qué valida automáticamente
+
+1. Tests unitarios del bridge (`PING/STOP` y parseo de `motion_status`).
+2. Chequeo serial de Fase A:
+   - `PING`
+   - `STOP` en ciclos
+   - `STATUS`
+
+## 3) Criterio para decir “funciona”
+
+Debes ver:
+
+- salida `OK` de `unittest`
+- líneas `PING seq=... -> ...`
+- líneas `STOP seq=... -> ...`
+- línea `STATUS seq=... -> ...`
+- mensaje final `✅ Fase A verificada`
+
+## 4) Si falla en hardware
+
+- Verifica puerto correcto (`/dev/ttyUSB0`, `/dev/ttyACM0`, etc.).
+- Verifica baudrate del firmware en `115200`.
+- Verifica que el firmware envíe JSON por línea (`\n`).
+- Verifica que el firmware implemente failsafe (timeout 1000 ms).

--- a/firmware/motion_esp32/README.md
+++ b/firmware/motion_esp32/README.md
@@ -1,0 +1,19 @@
+# motion_esp32 (Fase A)
+
+Este directorio define el firmware mínimo para el **ESP32 de Movimiento**.
+
+## Objetivo
+
+Implementar:
+
+- parser de JSON serial (`cmd_motion`)
+- comandos: `PING`, `STOP`, `SET_SAFE`, `SET_AUTO`, `SET_MANUAL`, `STATUS`
+- failsafe a 1000 ms (PWM neutro + `SAFE` + `TIMEOUT`)
+
+## Salidas esperadas
+
+- `motion_status` con `left_pwm`, `right_pwm`, `vertical_pwm`, `mode`, `error`
+
+## Nota
+
+No incluir aún SLAM/Kinect/mapa en este firmware base.

--- a/scripts/run-motion-phase-a.sh
+++ b/scripts/run-motion-phase-a.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-dry-run}"
+PORT="${2:-/dev/ttyUSB0}"
+
+echo "🚀 M.A.N.G.O Fase A runner ($MODE)"
+
+echo "[1/2] Ejecutando pruebas unitarias..."
+python3 -m unittest tests/serial_ping_stop_test.py
+
+echo "[2/2] Ejecutando chequeo serial PING/STOP/STATUS..."
+if [[ "$MODE" == "dry-run" ]]; then
+  python3 -m bridge.jetson_serial.phase_a_check --dry-run
+elif [[ "$MODE" == "hardware" ]]; then
+  python3 -m bridge.jetson_serial.phase_a_check --port "$PORT"
+else
+  echo "Modo inválido: $MODE (usa dry-run | hardware [port])" >&2
+  exit 1
+fi
+
+echo "✅ Fase A verificada"

--- a/tests/serial_ping_stop_test.py
+++ b/tests/serial_ping_stop_test.py
@@ -1,0 +1,51 @@
+import json
+import unittest
+
+from bridge.jetson_serial.motion_bridge import MotionBridge
+
+
+class FakeSerial:
+    def __init__(self):
+        self.writes = []
+        self.inbox = []
+
+    def write(self, data: bytes):
+        self.writes.append(data)
+
+    def readline(self) -> bytes:
+        if not self.inbox:
+            return b""
+        return self.inbox.pop(0)
+
+
+class MotionBridgeTest(unittest.TestCase):
+    def test_ping_and_stop_format(self):
+        fake = FakeSerial()
+        bridge = MotionBridge(fake)
+
+        seq_ping = bridge.ping()
+        seq_stop = bridge.stop(duration_ms=500)
+
+        self.assertEqual(seq_ping, 1)
+        self.assertEqual(seq_stop, 2)
+
+        ping_payload = json.loads(fake.writes[0].decode().strip())
+        stop_payload = json.loads(fake.writes[1].decode().strip())
+
+        self.assertEqual(ping_payload["cmd"], "PING")
+        self.assertEqual(stop_payload["cmd"], "STOP")
+        self.assertEqual(stop_payload["duration_ms"], 500)
+
+    def test_read_status(self):
+        fake = FakeSerial()
+        fake.inbox.append(
+            b'{"type":"motion_status","seq_ack":2,"mode":"SAFE","left_pwm":1500,"right_pwm":1500,"vertical_pwm":1500,"error":"NONE"}\n'
+        )
+        bridge = MotionBridge(fake)
+        status = bridge.read_status(timeout_s=0.2)
+        self.assertEqual(status["type"], "motion_status")
+        self.assertEqual(status["mode"], "SAFE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Establecer una base segura y testable para Fase A: validar comunicación Jetson/PC ↔ ESP32 Movimiento con `STOP` y failsafe antes de integrar SLAM/Kinect u otras cargas pesadas.
- Adaptar el arranque al contexto de Jetson TK1 priorizando un puente ligero y reglas de seguridad en lugar de procesamiento pesado en el borde.
- Proveer documentación y artefactos mínimos que permitan desarrollo incremental y pruebas automatizadas desde el primer día.

### Description

- Agrega `docs/protocols/MOTION_SERIAL_PROTOCOL.md` con transporte UART sobre USB, formato JSON por línea, conjunto de comandos (`PING`,`STOP`,`SET_*`,`STATUS`) y la regla de failsafe a `1000 ms`.
- Implementa `bridge/jetson_serial/motion_bridge.py` con `MotionCommand` y `MotionBridge` que soportan `ping()`, `stop()` y `read_status()` usando framing JSON por línea.
- Añade `firmware/motion_esp32/README.md` que define el alcance del firmware ESP32 de movimiento para Fase A (parser JSON, comandos mínimos y failsafe).
- Incluye pruebas unitarias `tests/serial_ping_stop_test.py` que usan `FakeSerial` para verificar el formato de `PING`/`STOP` y la lectura de `motion_status`.

### Testing

- Ejecutado `python3 -m unittest tests/serial_ping_stop_test.py` y las pruebas unitarias pasaron (`Ran 2 tests ... OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1453bb308323bef90f4ef50b3d38)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/t4t4n32/m_a_n_g_o/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->